### PR TITLE
docs: adds 'Welcome' to title of website landing page

### DIFF
--- a/open-tyndp-workshops/intro.md
+++ b/open-tyndp-workshops/intro.md
@@ -1,4 +1,4 @@
-# Open-TYNDP Workshops
+# Welcome: Open-TYNDP Workshops
 
 Welcome to the website covering a series of hands-on workshops facilitated by Open Energy Transition (OET) to accompany the development of an open-source energy modeling tool for the Ten-Year Network Development Plan (TYNDP).
 With every workshop a new notebook will be added to this website investigating different functionalities of PyPSA and implementations for the Open-TYNDP workflow.


### PR DESCRIPTION
Adds 'Welcome' to title of TYNDP-Workshops intro page to better distinguish from notebooks.